### PR TITLE
Fix: Prevent Extension Text from Copying with Ctrl + A on Webpages

### DIFF
--- a/src/contents/videoSelector.tsx
+++ b/src/contents/videoSelector.tsx
@@ -52,7 +52,7 @@ const VideoSelector = () => {
   return (
     <div
       className={`fixed right-0 flex  flex-col overflow-y-auto rounded-l-2xl border-y border-l bg-opacity-20 bg-gradient-to-br from-orange-400 to-violet-900 p-3  backdrop-blur-xl transition duration-300 ${
-        show ? "translate-x-0 opacity-100" : "translate-x-full opacity-0"
+        show ? "translate-x-0 opacity-100" : "translate-x-full opacity-0 select-none"
       } `}>
       <div className="flex">
         <h1 className="text-xl font-bold">Choose a video to sync</h1>


### PR DESCRIPTION
This PR addresses an issue where using `Ctrl + A` to select all and copy text inadvertently included content from the extension. The bug has been fixed to ensure only the intended page text is copied, excluding the extension’s content.

## Before

https://github.com/user-attachments/assets/2d020eb5-47c3-42d3-9e07-5a1b36618ca8


## After



https://github.com/user-attachments/assets/ec2e8b36-22bf-45f9-b185-0056868de38c

